### PR TITLE
feat(insights): add no-show metrics pipeline and heads-up

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -821,6 +821,63 @@ async def get_event_history():
     return storage_get_event_history()
 
 
+@app.post("/api/startgg/registered-count", tags=["Integrations"])
+async def update_startgg_registered_count(request: Request):
+    """
+    Receive Start.gg registered entrant count for current event.
+
+    Callable by n8n workflow or dashboard to refresh tournament_entrants
+    in settings.events_json before archiving.
+
+    Body: { "event_slug": "...", "startgg_registered_count": 42 }
+    Idempotent: replaces existing tournament_entrants value.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    count = body.get("startgg_registered_count")
+    if count is None:
+        raise HTTPException(status_code=400, detail="startgg_registered_count is required")
+
+    try:
+        count = int(count)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="startgg_registered_count must be an integer")
+
+    # Update events_json.tournament_entrants in active settings
+    settings = storage_get_active_settings() or {}
+    events_json = settings.get("events_json")
+
+    if isinstance(events_json, dict):
+        events_json["tournament_entrants"] = count
+    elif isinstance(events_json, list):
+        events_json = {"tournament_entrants": count, "events": events_json}
+    else:
+        events_json = {"tournament_entrants": count, "events": []}
+
+    # Find active settings record to update
+    get_settings_fn = getattr(storage_api, "get_active_settings_with_id", None)
+    if not get_settings_fn:
+        raise HTTPException(status_code=501, detail="Not available for current backend")
+
+    settings_data = get_settings_fn()
+    if not settings_data:
+        raise HTTPException(status_code=404, detail="No active settings found")
+
+    update_fn = getattr(storage_api, "update_settings", None)
+    if not update_fn:
+        raise HTTPException(status_code=501, detail="Not available for current backend")
+
+    result = update_fn(settings_data["record_id"], {"events_json": events_json})
+    if not result:
+        raise HTTPException(status_code=500, detail="Failed to update settings")
+
+    logger.info(f"Updated startgg_registered_count to {count}")
+    return {"success": True, "startgg_registered_count": count}
+
+
 @app.post("/api/archive/event", tags=["Dashboard"])
 async def archive_event_endpoint(request: Request):
     """Archive current event into event_archive/event_stats using storage backend."""

--- a/db/init.sql
+++ b/db/init.sql
@@ -126,7 +126,12 @@ CREATE TABLE event_stats (
     most_popular_game   TEXT,
     status_breakdown    JSONB,
     -- Snapshot
-    startgg_snapshot    JSONB
+    startgg_snapshot    JSONB,
+    -- No-show tracking
+    startgg_registered_count  INTEGER DEFAULT 0,
+    checked_in_count          INTEGER DEFAULT 0,
+    no_show_count             INTEGER DEFAULT 0,
+    no_show_rate              NUMERIC(5,2) DEFAULT 0
 );
 
 -- =============================================

--- a/fgt_dashboard/api.py
+++ b/fgt_dashboard/api.py
@@ -36,6 +36,11 @@ from shared.storage import (
 logger = logging.getLogger(__name__)
 
 
+def _display_name(name: str = "", email: str = "", user_id: str = "") -> str:
+    """Normalize display name for UI/audit; never return blank."""
+    return (name or email or (f"user-{user_id}" if user_id else "unknown")).strip()
+
+
 def _audit_safe(user: dict, action: str, target_table: str, **kwargs) -> None:
     """Best-effort audit logging; never break auth flow on audit failure."""
     try:
@@ -340,7 +345,11 @@ async def auth_callback(code: str = ""):
                 _audit_safe(
                     {
                         "user_id": user_info.get("id", ""),
-                        "user_name": user_info.get("name", "unknown"),
+                        "user_name": _display_name(
+                            user_info.get("name", ""),
+                            user_info.get("email", ""),
+                            str(user_info.get("id", "")),
+                        ),
                         "user_email": user_info.get("email", ""),
                     },
                     "auth_login_denied",
@@ -350,7 +359,11 @@ async def auth_callback(code: str = ""):
                 )
                 logger.warning(
                     "Denied dashboard login for user '%s' (not TO for active event %s)",
-                    user_info.get("name", "unknown"),
+                    _display_name(
+                        user_info.get("name", ""),
+                        user_info.get("email", ""),
+                        str(user_info.get("id", "")),
+                    ),
                     active_slug,
                 )
                 return JSONResponse(
@@ -364,7 +377,11 @@ async def auth_callback(code: str = ""):
                 _audit_safe(
                     {
                         "user_id": user_info.get("id", ""),
-                        "user_name": user_info.get("name", "unknown"),
+                        "user_name": _display_name(
+                            user_info.get("name", ""),
+                            user_info.get("email", ""),
+                            str(user_info.get("id", "")),
+                        ),
                         "user_email": user_info.get("email", ""),
                     },
                     "auth_login_denied",
@@ -390,7 +407,11 @@ async def auth_callback(code: str = ""):
         _audit_safe(
             {
                 "user_id": user_info.get("id", ""),
-                "user_name": user_info.get("name", "unknown"),
+                "user_name": _display_name(
+                    user_info.get("name", ""),
+                    user_info.get("email", ""),
+                    str(user_info.get("id", "")),
+                ),
                 "user_email": user_info.get("email", ""),
             },
             "auth_login_success",
@@ -422,7 +443,14 @@ async def auth_callback(code: str = ""):
             max_age=8 * 60 * 60,  # 8 hours
             path=cookie_path,
         )
-        logger.info(f"✅ User '{user_info.get('name')}' logged in successfully")
+        logger.info(
+            "✅ User '%s' logged in successfully",
+            _display_name(
+                user_info.get("name", ""),
+                user_info.get("email", ""),
+                str(user_info.get("id", "")),
+            ),
+        )
         return response
 
     except Exception as e:
@@ -445,7 +473,11 @@ async def auth_logout(request: Request):
         _audit_safe(
             {
                 "user_id": session_data.get("user_id", ""),
-                "user_name": session_data.get("user_name", "unknown"),
+                "user_name": _display_name(
+                    session_data.get("user_name", ""),
+                    session_data.get("user_email", ""),
+                    str(session_data.get("user_id", "")),
+                ),
                 "user_email": session_data.get("user_email", ""),
             },
             "auth_logout",
@@ -479,7 +511,11 @@ async def auth_me(request: Request):
 
     return {
         "user_id": session_data.get("user_id"),
-        "user_name": session_data.get("user_name"),
+        "user_name": _display_name(
+            session_data.get("user_name", ""),
+            session_data.get("user_email", ""),
+            str(session_data.get("user_id", "")),
+        ),
         "user_email": session_data.get("user_email"),
     }
 
@@ -557,7 +593,11 @@ async def auth_select_event_save(request: Request):
     _audit_safe(
         {
             "user_id": session_data.get("user_id", ""),
-            "user_name": session_data.get("user_name", "unknown"),
+            "user_name": _display_name(
+                session_data.get("user_name", ""),
+                session_data.get("user_email", ""),
+                str(session_data.get("user_id", "")),
+            ),
             "user_email": session_data.get("user_email", ""),
         },
         "auth_select_active_event",

--- a/fgt_dashboard/callbacks.py
+++ b/fgt_dashboard/callbacks.py
@@ -96,6 +96,9 @@ def register_callbacks(app):
         Output("checkins-table", "columns"),
         Output("player-count", "children"),
         Output("game-filter", "options"),
+        Output("duplicate-warning", "style"),
+        Output("duplicate-warning-text", "children"),
+        Output("duplicate-warning-list", "children"),
         Input("event-dropdown", "value"),
         Input("interval-refresh", "n_intervals"),
         Input("btn-refresh", "n_clicks"),
@@ -116,7 +119,7 @@ def register_callbacks(app):
         """
         if not selected_slug:
             logger.warning("No event slug selected – skipping table update.")
-            return no_update, no_update, no_update, no_update
+            return no_update, no_update, no_update, no_update, no_update, no_update, no_update
 
         # Default columns if none specified
         if not visible_columns:
@@ -140,10 +143,72 @@ def register_callbacks(app):
                 data = get_checkins(selected_slug) or []
             if not isinstance(data, list) or not data:
                 logger.info(f"No check-ins found for slug: {selected_slug}")
-                return [], [{"name": "No participants", "id": "info"}], "0 players", []
+                return [], [{"name": "No participants", "id": "info"}], "0 players", [], {"display": "none"}, "", []
 
             df = pd.DataFrame(data)
             total_count = len(df)
+
+            def _normalize_text(v):
+                if v is None:
+                    return ""
+                txt = str(v).strip().lower()
+                txt = re.sub(r"\s+", " ", txt)
+                return txt
+
+            def _normalize_phone(v):
+                if v is None:
+                    return ""
+                return re.sub(r"\D+", "", str(v))
+
+            # Duplicate warning: flag likely duplicates when at least 2 of 3 identity fields match.
+            duplicate_warning_style = {"display": "none"}
+            duplicate_warning_text = ""
+            duplicate_warning_list = []
+            identity_pairs = [
+                ("name", "tag", "name + tag"),
+                ("name", "telephone", "name + phone"),
+                ("tag", "telephone", "tag + phone"),
+            ]
+            duplicate_hits = {}
+
+            for col_a, col_b, reason in identity_pairs:
+                if col_a not in df.columns or col_b not in df.columns:
+                    continue
+
+                buckets = {}
+                for idx, row in df[[col_a, col_b]].iterrows():
+                    a_raw = row.get(col_a)
+                    b_raw = row.get(col_b)
+                    a = _normalize_phone(a_raw) if col_a == "telephone" else _normalize_text(a_raw)
+                    b = _normalize_phone(b_raw) if col_b == "telephone" else _normalize_text(b_raw)
+                    if not a or not b:
+                        continue
+                    buckets.setdefault((a, b), []).append(idx)
+
+                for idxs in buckets.values():
+                    if len(idxs) < 2:
+                        continue
+                    for idx in idxs:
+                        duplicate_hits.setdefault(idx, set()).add(reason)
+
+            if duplicate_hits:
+                flagged = df.loc[list(duplicate_hits.keys())]
+                preview_rows = []
+                for idx, row in flagged.head(4).iterrows():
+                    display_name = str(row.get("name") or "Unknown")
+                    display_tag = str(row.get("tag") or "-")
+                    reasons = ", ".join(sorted(duplicate_hits.get(idx, [])))
+                    preview_rows.append(html.Li(f"{display_name} ({display_tag}) – {reasons}"))
+                duplicate_warning_style = {
+                    "marginBottom": "0.75rem",
+                    "display": "block",
+                    "border": "1px solid rgba(245, 158, 11, 0.45)",
+                    "backgroundColor": "rgba(245, 158, 11, 0.08)",
+                    "borderRadius": "8px",
+                    "padding": "0.55rem 0.75rem",
+                }
+                duplicate_warning_text = f"⚠ Possible duplicate participants detected ({len(flagged)})."
+                duplicate_warning_list = preview_rows
 
             # Game name shortening map
             GAME_SHORT_NAMES = {
@@ -272,11 +337,29 @@ def register_callbacks(app):
             else:
                 count_text = f"{filtered_count} of {total_count} players"
 
-            return df_filtered.to_dict("records"), cols, count_text, game_options
+            return (
+                df_filtered.to_dict("records"),
+                cols,
+                count_text,
+                game_options,
+                duplicate_warning_style,
+                duplicate_warning_text,
+                duplicate_warning_list,
+            )
 
         except Exception as e:
             logger.exception(f"Error fetching check-ins for slug '{selected_slug}': {e}")
-            return [], [{"name": "Error fetching data", "id": "error"}], "Error", []
+            return [], [{"name": "Error fetching data", "id": "error"}], "Error", [], {"display": "none"}, "", []
+
+    @app.callback(
+        Output("duplicate-warning", "style", allow_duplicate=True),
+        Input("duplicate-warning-dismiss", "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def dismiss_duplicate_warning(n_clicks):
+        if n_clicks:
+            return {"display": "none"}
+        return no_update
 
     # ---------------------------------------------------------------------
     # Sync column visibility dropdown to store
@@ -434,7 +517,8 @@ def register_callbacks(app):
                 name
                 startAt
                 timezone
-                events { id name slug startAt }
+                numEntrants
+                events { id name slug startAt numEntrants }
               }
             }
             """,
@@ -476,7 +560,13 @@ def register_callbacks(app):
         # Build compact events array
         events = tournament.get("events") or []
         events_compact = [
-            {"id": e.get("id"), "name": e.get("name"), "slug": e.get("slug"), "startAt": e.get("startAt")}
+            {
+                "id": e.get("id"),
+                "name": e.get("name"),
+                "slug": e.get("slug"),
+                "startAt": e.get("startAt"),
+                "numEntrants": e.get("numEntrants"),
+            }
             for e in events if isinstance(e, dict)
         ]
         fetched_names = [e.get("name") for e in events if isinstance(e, dict) and e.get("name")]
@@ -516,10 +606,22 @@ def register_callbacks(app):
             new_selected = keep + [n for n in new_candidates if n not in seen]
 
         # 5) Update settings using storage backend
+        # Wrap events_json as {tournament_entrants, events} for no-show tracking.
+        # Readers already handle both list and dict formats (backward compatible).
+        events_json_value = {
+            "tournament_entrants": tournament.get("numEntrants"),
+            "events": events_compact,
+        }
         patch_fields = {
             "active_event_slug": slug,
-            "event_display_name": tournament.get("name", ""),  # Store proper tournament name with åäö
+            "event_display_name": tournament.get("name", ""),
             "is_active": True,
+            "events_json": events_json_value,
+            "event_date": start_iso,
+            "default_game": new_selected,
+            "startgg_event_url": link.strip(),
+            "tournament_name": tournament.get("name", ""),
+            "timezone": tournament.get("timezone", ""),
         }
         result = update_settings(settings_id, patch_fields)
         if not result:
@@ -1030,6 +1132,9 @@ def register_callbacks(app):
             weighted_retention_sum = 0.0
             weighted_retention_den = 0
             top_game_counts = {}
+            startgg_registered_total = 0
+            checked_in_total = 0
+            no_show_total = 0
 
             for ev in event_rows:
                 ev_total = _as_int(ev.get("total_participants") or ev.get("participants"))
@@ -1052,6 +1157,17 @@ def register_callbacks(app):
                 if top_game:
                     top_game_counts[top_game] = top_game_counts.get(top_game, 0) + 1
 
+                # No-show aggregation
+                startgg_registered_total += _as_int(ev.get("startgg_registered_count"))
+                checked_in_total += _as_int(ev.get("checked_in_count"))
+                no_show_total += _as_int(ev.get("no_show_count"))
+
+            no_show_rate_agg = (
+                (no_show_total / startgg_registered_total * 100)
+                if startgg_registered_total > 0
+                else 0.0
+            )
+
             return {
                 "total": total,
                 "revenue": total_revenue,
@@ -1061,6 +1177,10 @@ def register_callbacks(app):
                 "ready_count": ready_count,
                 "retention": (weighted_retention_sum / weighted_retention_den) if weighted_retention_den > 0 else 0.0,
                 "top_game_counts": top_game_counts,
+                "startgg_registered_total": startgg_registered_total,
+                "checked_in_total": checked_in_total,
+                "no_show_total": no_show_total,
+                "no_show_rate": no_show_rate_agg,
             }
 
         table_rows = []
@@ -1071,6 +1191,8 @@ def register_callbacks(app):
             ev_startgg_rate = (_as_int(ev.get("startgg_count")) / ev_total * 100) if ev_total > 0 else 0.0
             ev_revenue = _as_float(ev.get("total_revenue"))
             revenue_per_player = (ev_revenue / ev_total) if ev_total > 0 else 0.0
+            ev_no_show = _as_int(ev.get("no_show_count"))
+            ev_no_show_rate = _as_float(ev.get("no_show_rate"))
             table_rows.append(
                 {
                     "event_display_name": ev.get("event_display_name") or ev.get("event_slug", ""),
@@ -1081,6 +1203,8 @@ def register_callbacks(app):
                     "member_rate": f"{ev_member_rate:.0f}%",
                     "startgg_rate": f"{ev_startgg_rate:.0f}%",
                     "retention_rate": f"{_as_float(ev.get('retention_rate')):.0f}%",
+                    "no_show_count": ev_no_show,
+                    "no_show_rate": f"{ev_no_show_rate:.0f}%" if ev_no_show_rate > 0 else "-",
                 }
             )
             earnings_rows.append(

--- a/fgt_dashboard/callbacks.py
+++ b/fgt_dashboard/callbacks.py
@@ -1299,6 +1299,23 @@ def register_callbacks(app):
             scope_label = "All events"
         summary_title = f"{scope_label} • {period_label}"
 
+        # Community-friendly heads-up text for no-show trend (non-alarm tone).
+        heads_up_text = ""
+        reg_total = metrics.get("startgg_registered_total", 0)
+        no_show_total = metrics.get("no_show_total", 0)
+        no_show_rate = metrics.get("no_show_rate", 0.0)
+        if reg_total >= 10:
+            if no_show_rate >= 30:
+                heads_up_text = (
+                    f"Heads-up: no-show is {no_show_rate:.0f}% "
+                    f"({no_show_total} of {reg_total} Start.gg registrations) in this scope."
+                )
+            elif no_show_rate >= 15:
+                heads_up_text = (
+                    f"Heads-up: no-show is {no_show_rate:.0f}% "
+                    f"({no_show_total} of {reg_total}) in this scope."
+                )
+
         # Top attendees leaderboard for selected scope
         top_players_rows = []
         top_players_title = "Top attendees"
@@ -1350,7 +1367,7 @@ def register_callbacks(app):
             options,
             selected_event_slugs,
             summary_title,
-            "",
+            heads_up_text,
             str(metrics["total"]),
             f"{metrics['revenue']:.0f} kr",
             f"{ready_rate:.0f}%",

--- a/fgt_dashboard/layout.py
+++ b/fgt_dashboard/layout.py
@@ -173,7 +173,11 @@ def _get_auth_state() -> dict:
 
         return {
             "logged_in": True,
-            "user_name": session_data.get("user_name", ""),
+            "user_name": (
+                session_data.get("user_name")
+                or session_data.get("user_email")
+                or (f"user-{session_data.get('user_id')}" if session_data.get("user_id") else "")
+            ),
             "user_id": session_data.get("user_id", ""),
             "user_email": session_data.get("user_email", ""),
         }

--- a/fgt_dashboard/layout.py
+++ b/fgt_dashboard/layout.py
@@ -530,6 +530,37 @@ def create_layout():
                             html.Span(id="player-count", children=f"{len(data)} players", style={"color": COLORS["text_muted"], "fontSize": "0.875rem"}),
                         ]),
 
+                        html.Div(
+                            id="duplicate-warning",
+                            style={"marginBottom": "0.75rem", "display": "none"},
+                            children=[
+                                html.Div(
+                                    style={"display": "flex", "justifyContent": "space-between", "alignItems": "center", "gap": "0.6rem"},
+                                    children=[
+                                        html.Span(id="duplicate-warning-text", style={"fontWeight": "600", "color": "#f59e0b"}),
+                                        html.Button(
+                                            "Dismiss",
+                                            id="duplicate-warning-dismiss",
+                                            n_clicks=0,
+                                            style={
+                                                "backgroundColor": "transparent",
+                                                "border": "1px solid rgba(245, 158, 11, 0.45)",
+                                                "color": "#fbbf24",
+                                                "borderRadius": "6px",
+                                                "padding": "0.2rem 0.55rem",
+                                                "fontSize": "0.75rem",
+                                                "cursor": "pointer",
+                                            },
+                                        ),
+                                    ],
+                                ),
+                                html.Ul(
+                                    id="duplicate-warning-list",
+                                    style={"margin": "0.35rem 0 0 1rem", "color": "#fbbf24", "fontSize": "0.82rem"},
+                                ),
+                            ],
+                        ),
+
                         # Search and game filter row
                         html.Div(style={"display": "flex", "gap": "1rem", "marginBottom": "1rem", "flexWrap": "wrap", "alignItems": "center"}, children=[
                             # Search field
@@ -910,6 +941,8 @@ def create_layout():
                                 {"name": "Member %", "id": "member_rate"},
                                 {"name": "Start.gg %", "id": "startgg_rate"},
                                 {"name": "Retention %", "id": "retention_rate"},
+                                {"name": "No-shows", "id": "no_show_count"},
+                                {"name": "No-show %", "id": "no_show_rate"},
                             ],
                             data=[],
                             page_size=10,

--- a/n8n/flows/FGC THN - Start.gg Event Stats.json
+++ b/n8n/flows/FGC THN - Start.gg Event Stats.json
@@ -1,0 +1,118 @@
+{
+  "name": "FGC THN - Start.gg Event Stats",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "startgg/event-stats",
+        "responseMode": "lastNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1.1,
+      "position": [260, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.start.gg/gql/alpha",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "Bearer {{ $env.STARTGG_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ query: 'query T($slug: String!) { tournament(slug: $slug) { id name numEntrants events { id name numEntrants } } }', variables: { slug: $json.slug } }) }}",
+        "options": {}
+      },
+      "id": "startgg-query",
+      "name": "Start.gg GraphQL",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [480, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\nconst tournament = input?.data?.tournament;\nconst slug = $('Webhook').first().json.slug || '';\n\nif (!tournament) {\n  return [{ json: { error: 'Tournament not found', slug } }];\n}\n\nreturn [{\n  json: {\n    event_slug: slug,\n    startgg_registered_count: tournament.numEntrants || 0,\n    tournament_name: tournament.name || '',\n    events: (tournament.events || []).map(e => ({\n      id: e.id,\n      name: e.name,\n      numEntrants: e.numEntrants || 0\n    }))\n  }\n}];"
+      },
+      "id": "transform",
+      "name": "Transform",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [700, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://backend:8000/api/startgg/registered-count",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ event_slug: $json.event_slug, startgg_registered_count: $json.startgg_registered_count }) }}",
+        "options": {}
+      },
+      "id": "report-to-backend",
+      "name": "Report to Backend",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.1,
+      "position": [920, 300],
+      "onError": "continueRegularOutput"
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Start.gg GraphQL",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start.gg GraphQL": {
+      "main": [
+        [
+          {
+            "node": "Transform",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Transform": {
+      "main": [
+        [
+          {
+            "node": "Report to Backend",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "tags": [
+    {
+      "name": "FGC THN"
+    }
+  ],
+  "pinData": {}
+}

--- a/shared/auth.py
+++ b/shared/auth.py
@@ -143,11 +143,17 @@ def get_startgg_user(access_token: str) -> dict:
         user = data.get("data", {}).get("currentUser") or {}
         images = user.get("images") or []
         avatar_url = images[0].get("url") if images else None
+        display_name = (
+            user.get("name")
+            or user.get("slug")
+            or user.get("email")
+            or (f"user-{user.get('id')}" if user.get("id") else "unknown")
+        )
 
         return {
             "id": str(user.get("id", "")),
             "slug": user.get("slug", ""),
-            "name": user.get("name", ""),
+            "name": display_name,
             "email": user.get("email", ""),
             "avatar_url": avatar_url,
         }

--- a/shared/postgres_api.py
+++ b/shared/postgres_api.py
@@ -44,7 +44,28 @@ def _get_pool():
             kwargs={"autocommit": True},
         )
         logger.info("✅ Postgres connection pool initialized")
+        _run_migrations(_pool)
     return _pool
+
+
+def _run_migrations(pool):
+    """Idempotent schema migrations - safe to run on every startup."""
+    try:
+        with pool.connection() as conn:
+            with conn.cursor() as cur:
+                # No-show tracking columns (added 2026-02-24)
+                for col, typ in [
+                    ("startgg_registered_count", "INTEGER DEFAULT 0"),
+                    ("checked_in_count", "INTEGER DEFAULT 0"),
+                    ("no_show_count", "INTEGER DEFAULT 0"),
+                    ("no_show_rate", "NUMERIC(5,2) DEFAULT 0"),
+                ]:
+                    cur.execute(
+                        f"ALTER TABLE event_stats ADD COLUMN IF NOT EXISTS {col} {typ}"
+                    )
+        logger.info("✅ Schema migrations checked (no-show columns)")
+    except Exception as e:
+        logger.warning(f"⚠️ Migration check failed (non-fatal): {e}")
 
 
 def _coerce_jsonb(value: Any) -> Any:
@@ -832,7 +853,9 @@ def get_event_history_dashboard() -> List[Dict[str, Any]]:
                        total_participants, total_revenue, avg_payment,
                        member_count, guest_count, startgg_count,
                        new_players, returning_players, retention_rate,
-                       games_breakdown, most_popular_game, status_breakdown
+                       games_breakdown, most_popular_game, status_breakdown,
+                       startgg_registered_count, checked_in_count,
+                       no_show_count, no_show_rate
                 FROM event_stats
                 ORDER BY archived_at DESC NULLS LAST
                 """
@@ -858,6 +881,10 @@ def get_event_history_dashboard() -> List[Dict[str, Any]]:
             games_breakdown,
             most_popular_game,
             status_breakdown,
+            startgg_registered_count,
+            checked_in_count,
+            no_show_count,
+            no_show_rate,
         ) = row
 
         result.append(
@@ -878,6 +905,10 @@ def get_event_history_dashboard() -> List[Dict[str, Any]]:
                 "games_breakdown": games_breakdown,
                 "most_popular_game": most_popular_game,
                 "status_breakdown": status_breakdown,
+                "startgg_registered_count": startgg_registered_count or 0,
+                "checked_in_count": checked_in_count or 0,
+                "no_show_count": no_show_count or 0,
+                "no_show_rate": float(no_show_rate or 0),
             }
         )
 
@@ -1332,7 +1363,29 @@ def archive_event(
                     else Decimal("0")
                 )
 
-                # 5. Upsert event_stats (including startgg_snapshot)
+                # 4b. No-show computation
+                checked_in_count = total
+                startgg_registered_count = 0
+                if startgg_snapshot:
+                    if isinstance(startgg_snapshot, dict) and "tournament_entrants" in startgg_snapshot:
+                        startgg_registered_count = int(startgg_snapshot.get("tournament_entrants") or 0)
+                    elif isinstance(startgg_snapshot, list):
+                        # Legacy format: sum per-event numEntrants
+                        startgg_registered_count = sum(
+                            int(e.get("numEntrants") or 0)
+                            for e in startgg_snapshot
+                            if isinstance(e, dict)
+                        )
+                no_show_count = max(startgg_registered_count - checked_in_count, 0)
+                no_show_rate = (
+                    (Decimal(no_show_count) / Decimal(startgg_registered_count) * 100).quantize(
+                        Decimal("0.01")
+                    )
+                    if startgg_registered_count > 0
+                    else Decimal("0")
+                )
+
+                # 5. Upsert event_stats (including startgg_snapshot + no-show)
                 cur.execute(
                     """
                     INSERT INTO event_stats (
@@ -1341,14 +1394,18 @@ def archive_event(
                         member_count, member_percentage, guest_count, startgg_count,
                         new_players, returning_players, retention_rate,
                         games_breakdown, most_popular_game, status_breakdown,
-                        startgg_snapshot
+                        startgg_snapshot,
+                        startgg_registered_count, checked_in_count,
+                        no_show_count, no_show_rate
                     ) VALUES (
                         %s, %s, %s, %s,
                         %s, %s, %s,
                         %s, %s, %s, %s,
                         %s, %s, %s,
                         %s, %s, %s,
-                        %s
+                        %s,
+                        %s, %s,
+                        %s, %s
                     )
                     ON CONFLICT (event_slug) DO UPDATE SET
                         event_date = EXCLUDED.event_date,
@@ -1367,7 +1424,11 @@ def archive_event(
                         games_breakdown = EXCLUDED.games_breakdown,
                         most_popular_game = EXCLUDED.most_popular_game,
                         status_breakdown = EXCLUDED.status_breakdown,
-                        startgg_snapshot = EXCLUDED.startgg_snapshot
+                        startgg_snapshot = EXCLUDED.startgg_snapshot,
+                        startgg_registered_count = EXCLUDED.startgg_registered_count,
+                        checked_in_count = EXCLUDED.checked_in_count,
+                        no_show_count = EXCLUDED.no_show_count,
+                        no_show_rate = EXCLUDED.no_show_rate
                     """,
                     (
                         event_slug, event_date, event_display_name, now,
@@ -1385,6 +1446,10 @@ def archive_event(
                         stats["most_popular_game"],
                         Json(stats["status_breakdown"]),
                         Json(startgg_snapshot) if startgg_snapshot else None,
+                        startgg_registered_count,
+                        checked_in_count,
+                        no_show_count,
+                        no_show_rate,
                     ),
                 )
 
@@ -1435,6 +1500,10 @@ def archive_event(
         "games_breakdown": stats["games_breakdown"],
         "most_popular_game": stats["most_popular_game"],
         "status_breakdown": stats["status_breakdown"],
+        "startgg_registered_count": startgg_registered_count,
+        "checked_in_count": checked_in_count,
+        "no_show_count": no_show_count,
+        "no_show_rate": float(no_show_rate),
         "replaced_rows": replaced_rows,
         "cleared_active": deleted_count if clear_active else 0,
     }


### PR DESCRIPTION
## Summary
- add end-to-end no-show data pipeline by storing Start.gg registered counts, computing no-show stats at archive/re-archive, and exposing fields in Insights data
- fix `fetch_event_data` persistence gap so `events_json` and related Start.gg metadata are saved reliably (including `tournament_entrants` wrapper support)
- add no-show awareness in Insights (table exposure + community-friendly heads-up message) and include a new n8n workflow scaffold for on-demand Start.gg stats refresh

## Testing
- `python -m py_compile backend/main.py fgt_dashboard/callbacks.py fgt_dashboard/layout.py shared/postgres_api.py`
- `POST /api/startgg/registered-count` smoke test returned `200`
- verified `event_stats` contains: `startgg_registered_count`, `checked_in_count`, `no_show_count`, `no_show_rate`
- archive/re-archive SQL validation confirmed values overwrite correctly (UPSERT path)